### PR TITLE
feat: :sparkles: Added testing, amended getRoutes() to return

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -7,7 +7,5 @@ app.get("/user/:id", (req: Request) => {
   return new Response(req.params.id);
 });
 
-app.getRoutes()
-
 app.start(80);
 

--- a/main_test.ts
+++ b/main_test.ts
@@ -1,0 +1,41 @@
+import { assertEquals } from "@std/assert";
+import DynamicResponder from "./responder.ts";
+
+const testPort = 8080;
+
+
+/* SERVER */ 
+const app = new DynamicResponder();
+
+app.get("/user/:id", (req: Request) => {
+    return new Response(req.params.id);
+});
+
+app.get("/:id", (req: Request) => {
+    return new Response(req.params.id);
+});
+  
+app.get("/", (_req: Request) => {
+    return new Response("This is a standard response");
+});
+
+app.start(testPort);
+
+
+Deno.test(async function userParamResponse() {
+    const response = await fetch(`http://localhost:${testPort}/user/testaccount`);
+    const text = await response.text();
+    assertEquals(text, "testaccount", "Param response is unexpected")
+});
+
+Deno.test(async function idParamResponse() {
+    const response = await fetch(`http://localhost:${testPort}/test`);
+    const text = await response.text();
+    assertEquals(text, "test", "Param response is unexpected")
+});
+
+Deno.test(async function defaultResponse() {
+    const response = await fetch(`http://localhost:${testPort}/`);
+    const text = await response.text();
+    assertEquals(text, "This is a standard response", "Param response is unexpected")
+});

--- a/responder.ts
+++ b/responder.ts
@@ -50,7 +50,7 @@ export default class DynamicResponder {
     }
 
     public getRoutes(){
-        console.log(this.router)
+        return this.router;
     }
 
     start(port: number, hostname: string = "0.0.0.0"){


### PR DESCRIPTION
Added main_test.ts using Deno asserts to test the server deployment for standardised testing, amended getRoutes() to use return instead of console.log to be more usable. Amended the main.ts to remove getRoutes() call